### PR TITLE
use openjdk:8-jdk-slim as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM java:openjdk-8
+FROM openjdk:8-jdk-slim
 MAINTAINER Hortonworks
 
 # Install starter script for the Periscope application
 COPY bootstrap/start_periscope_app.sh /start_periscope_app.sh
 
 # Install zip
-RUN apt-get update
-RUN apt-get install zip
+RUN apt-get update --no-install-recommends && apt-get install -y zip procps
 
 ENV VERSION 2.4.0-rc.2
 # install the periscope app


### PR DESCRIPTION
Modify Dockerfile to use openjdk:8-jdk-slim as base image because java images had been deprecated and didn't updated since 2016-12-31.

@keyki Please merge after the release of the Cloudbreak's 2.4.0 version.