### PR TITLE
Update REPO url to use HWX standard repo url 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
-FROM openjdk:10-jdk-slim
+FROM hortonworks/hwx_openjdk:10-jdk-slim
 MAINTAINER Hortonworks
+
+# REPO URL to download jar
+ARG REPO_URL=http://repo.hortonworks.com/content/repositories/releases
+ARG VERSION=''
 
 # Install starter script for the Periscope application
 COPY bootstrap/start_periscope_app.sh /start_periscope_app.sh
@@ -7,9 +11,9 @@ COPY bootstrap/start_periscope_app.sh /start_periscope_app.sh
 # Install zip
 RUN apt-get update --no-install-recommends && apt-get install -y zip procps
 
-ENV VERSION 2.9.0-dev.128
+ENV VERSION ${VERSION}
 # install the periscope app
-ADD https://cloudbreak-maven.s3.amazonaws.com/releases/com/sequenceiq/periscope/$VERSION/periscope-$VERSION.jar /periscope.jar
+ADD ${REPO_URL}/com/sequenceiq/periscope/$VERSION/periscope-$VERSION.jar /periscope.jar
 
 # add jmx exporter
 ADD jmx_prometheus_javaagent-0.10.jar /jmx_prometheus_javaagent.jar

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 export MAVEN_METADATA_URL = maven.sequenceiq.com/releases/com/sequenceiq/periscope/maven-metadata.xml
-export DOCKER_IMAGE = hortonworks/cloudbreak-autoscale
 
 dockerhub:
 	./deploy.sh $(VERSION)


### PR DESCRIPTION
1. Updating base image to use HWX base image
2. Instead of dockerhub-tag creating the images, using docker command to create images, this gives us the flexibility to create dev and rc releases image independently, also we use different repo url in dev and production environment. 